### PR TITLE
Use darling::Error to preserve spans

### DIFF
--- a/entity_macros/Cargo.toml
+++ b/entity_macros/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-darling = "0.11.0"
+darling = "0.12.0"
 heck = "0.3.1"
 proc-macro2 = "1.0.24"
 proc-macro-crate = "0.1.5"

--- a/entity_macros/src/attribute.rs
+++ b/entity_macros/src/attribute.rs
@@ -1,5 +1,4 @@
 use crate::utils;
-use darling::util::SpannedValue;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
@@ -217,8 +216,9 @@ fn inject_ent_id_field(
         struct_info.has_conflicting_id_name,
         struct_info.has_id_marker,
     ) {
-        (Some(span), None) => Err(darling::Error::custom("Conflicting field with same name")
-            .with_span(&SpannedValue::new((), span))),
+        (Some(span), None) => {
+            Err(darling::Error::custom("Conflicting field with same name").with_span(&span))
+        }
         (_, Some(_)) => Ok(()),
         (None, None) => {
             match &mut item.fields {
@@ -262,8 +262,9 @@ fn inject_ent_database_field(
         struct_info.has_conflicting_database_name,
         struct_info.has_database_marker,
     ) {
-        (Some(span), None) => Err(darling::Error::custom("Conflicting field with same name")
-            .with_span(&SpannedValue::new((), span))),
+        (Some(span), None) => {
+            Err(darling::Error::custom("Conflicting field with same name").with_span(&span))
+        }
         (_, Some(_)) => Ok(()),
         (None, None) => {
             match &mut item.fields {
@@ -314,8 +315,9 @@ fn inject_ent_created_field(
         struct_info.has_conflicting_created_name,
         struct_info.has_created_marker,
     ) {
-        (Some(span), None) => Err(darling::Error::custom("Conflicting field with same name")
-            .with_span(&SpannedValue::new((), span))),
+        (Some(span), None) => {
+            Err(darling::Error::custom("Conflicting field with same name").with_span(&span))
+        }
         (_, Some(_)) => Ok(()),
         (None, None) => {
             match &mut item.fields {
@@ -356,8 +358,9 @@ fn inject_ent_last_updated_field(
         struct_info.has_conflicting_last_updated_name,
         struct_info.has_last_updated_marker,
     ) {
-        (Some(span), None) => Err(darling::Error::custom("Conflicting field with same name")
-            .with_span(&SpannedValue::new((), span))),
+        (Some(span), None) => {
+            Err(darling::Error::custom("Conflicting field with same name").with_span(&span))
+        }
         (_, Some(_)) => Ok(()),
         (None, None) => {
             match &mut item.fields {

--- a/entity_macros/src/derive/ent/mod.rs
+++ b/entity_macros/src/derive/ent/mod.rs
@@ -2,12 +2,12 @@ mod r#enum;
 mod r#struct;
 
 use proc_macro2::TokenStream;
-use syn::{spanned::Spanned, Data, DeriveInput, Path};
+use syn::{Data, DeriveInput, Path};
 
-pub fn do_derive_ent(root: Path, input: DeriveInput) -> Result<TokenStream, syn::Error> {
+pub fn do_derive_ent(root: Path, input: DeriveInput) -> darling::Result<TokenStream> {
     match &input.data {
         Data::Struct(_) => r#struct::do_derive_ent(root, input),
         Data::Enum(_) => r#enum::do_derive_ent(root, input),
-        Data::Union(_) => Err(syn::Error::new(input.span(), "Unions are not supported")),
+        Data::Union(_) => Err(darling::Error::custom("Unions are not supported").with_span(&input)),
     }
 }

--- a/entity_macros/src/derive/ent/struct/builder.rs
+++ b/entity_macros/src/derive/ent/struct/builder.rs
@@ -8,7 +8,7 @@ pub fn impl_ent_builder(
     root: &Path,
     input: &DeriveInput,
     ent: &Ent,
-) -> Result<TokenStream, syn::Error> {
+) -> darling::Result<TokenStream> {
     let ent_name = &input.ident;
     let builder_name = format_ident!("{}Builder", ent_name);
     let builder_error_name = format_ident!("{}Error", builder_name);

--- a/entity_macros/src/derive/ent/struct/data/mod.rs
+++ b/entity_macros/src/derive/ent/struct/data/mod.rs
@@ -116,9 +116,8 @@ impl FromDeriveInput for Ent {
                 }
             } else if f.is_ent_database_field {
                 if database.is_some() {
-                    return Err(
-                        darling::Error::custom("Already have a database elsewhere").with_span(&name)
-                    );
+                    return Err(darling::Error::custom("Already have a database elsewhere")
+                        .with_span(&name));
                 } else {
                     database = Some(name);
                 }

--- a/entity_macros/src/derive/ent/struct/edge.rs
+++ b/entity_macros/src/derive/ent/struct/edge.rs
@@ -11,7 +11,7 @@ pub(crate) fn impl_typed_edge_methods(
     name: &Ident,
     generics: &Generics,
     edges: &[EntEdge],
-) -> Result<TokenStream, syn::Error> {
+) -> darling::Result<TokenStream> {
     let mut edge_methods: Vec<TokenStream> = Vec::new();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -29,7 +29,7 @@ pub(crate) fn impl_typed_edge_methods(
     })
 }
 
-fn fn_typed_id_getter(edge: &EntEdge) -> Result<TokenStream, syn::Error> {
+fn fn_typed_id_getter(edge: &EntEdge) -> darling::Result<TokenStream> {
     let name = &edge.name;
     let ty = &edge.ty;
 

--- a/entity_macros/src/derive/ent/struct/mod.rs
+++ b/entity_macros/src/derive/ent/struct/mod.rs
@@ -5,21 +5,21 @@ mod ent;
 mod field;
 mod query;
 
+use darling::FromDeriveInput;
 pub use data::{Ent, EntEdge, EntEdgeDeletionPolicy, EntEdgeKind, EntField};
 
 use crate::utils;
 use heck::ShoutySnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use std::convert::TryFrom;
 use syn::{DeriveInput, Path};
 
-pub fn do_derive_ent(root: Path, input: DeriveInput) -> Result<TokenStream, syn::Error> {
+pub fn do_derive_ent(root: Path, input: DeriveInput) -> darling::Result<TokenStream> {
     let name = &input.ident;
     let vis = &input.vis;
     let generics = &input.generics;
     let const_type_name = format_ident!("{}_TYPE", name.to_string().to_shouty_snake_case());
-    let ent = Ent::try_from(&input)?;
+    let ent = Ent::from_derive_input(&input)?;
 
     // Define a constant with a string representing the unique type of the ent
     let const_type_t = quote! {

--- a/entity_macros/src/derive/ent/struct/query.rs
+++ b/entity_macros/src/derive/ent/struct/query.rs
@@ -11,7 +11,7 @@ pub fn impl_ent_query(
     generics: &Generics,
     const_type_name: &Ident,
     ent: &Ent,
-) -> Result<TokenStream, syn::Error> {
+) -> darling::Result<TokenStream> {
     let query_name = format_ident!("{}Query", name);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let ty_phantoms: Vec<Type> = generics

--- a/entity_macros/src/derive/value/mod.rs
+++ b/entity_macros/src/derive/value/mod.rs
@@ -3,9 +3,9 @@ mod unit;
 mod unnamed;
 
 use proc_macro2::TokenStream;
-use syn::{spanned::Spanned, Data, DeriveInput, Fields, Path};
+use syn::{Data, DeriveInput, Fields, Path};
 
-pub fn do_derive_value(root: Path, input: DeriveInput) -> Result<TokenStream, syn::Error> {
+pub fn do_derive_value(root: Path, input: DeriveInput) -> darling::Result<TokenStream> {
     let name = &input.ident;
     let generics = &input.generics;
 
@@ -15,7 +15,7 @@ pub fn do_derive_value(root: Path, input: DeriveInput) -> Result<TokenStream, sy
             Fields::Unnamed(x) => Ok(unnamed::make(&root, name, generics, x)),
             Fields::Unit => Ok(unit::make(&root, name, generics)),
         },
-        Data::Enum(_) => Err(syn::Error::new(input.span(), "Enums are unsupported")),
-        Data::Union(_) => Err(syn::Error::new(input.span(), "Unions are unsupported")),
+        Data::Enum(_) => Err(darling::Error::custom("Enums are unsupported").with_span(&input)),
+        Data::Union(_) => Err(darling::Error::custom("Unions are unsupported").with_span(&input)),
     }
 }

--- a/entity_macros/src/lib.rs
+++ b/entity_macros/src/lib.rs
@@ -94,7 +94,7 @@ pub fn derive_ent(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let expanded = utils::entity_crate()
         .and_then(|root| derive::do_derive_ent(root, input))
-        .unwrap_or_else(|x| x.to_compile_error());
+        .unwrap_or_else(|x| x.write_errors());
 
     proc_macro::TokenStream::from(expanded)
 }
@@ -105,7 +105,7 @@ pub fn derive_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let expanded = utils::entity_crate()
         .and_then(|root| derive::do_derive_value(root, input))
-        .unwrap_or_else(|x| x.to_compile_error());
+        .unwrap_or_else(|x| x.write_errors());
 
     proc_macro::TokenStream::from(expanded)
 }
@@ -131,7 +131,7 @@ pub fn simple_ent(
 
     let expanded = utils::entity_crate()
         .and_then(|root| attribute::do_simple_ent(root, args, item))
-        .unwrap_or_else(|x| x.to_compile_error());
+        .unwrap_or_else(|x| x.write_errors());
 
     proc_macro::TokenStream::from(expanded)
 }

--- a/entity_macros/src/utils.rs
+++ b/entity_macros/src/utils.rs
@@ -13,10 +13,7 @@ pub fn entity_crate() -> darling::Result<Path> {
             let crate_ident = Ident::new(&name, Span::mixed_site());
             parse_quote!(::#crate_ident)
         })
-        .map_err(|msg| {
-            darling::Error::custom(msg)
-                .with_span(&darling::util::SpannedValue::new((), Span::mixed_site()))
-        })
+        .map_err(|msg| darling::Error::custom(msg).with_span(&Span::mixed_site()))
 }
 
 /// Produces a token stream in the form of `::serde` or renamed version

--- a/entity_macros/src/utils.rs
+++ b/entity_macros/src/utils.rs
@@ -2,28 +2,31 @@ use proc_macro2::Span;
 use proc_macro_crate::crate_name;
 use std::collections::HashMap;
 use syn::{
-    parse_quote, spanned::Spanned, Attribute, Data, DeriveInput, Expr, Fields, FieldsNamed,
-    GenericArgument, Ident, Lit, Meta, NestedMeta, Path, PathArguments, PathSegment, Type,
+    parse_quote, Attribute, Data, DeriveInput, Expr, Fields, FieldsNamed, GenericArgument, Ident,
+    Lit, Meta, NestedMeta, Path, PathArguments, PathSegment, Type,
 };
 
 /// Produces a token stream in the form of `::entity` or renamed version
-pub fn entity_crate() -> Result<Path, syn::Error> {
+pub fn entity_crate() -> darling::Result<Path> {
     crate_name("entity")
         .map(|name| {
             let crate_ident = Ident::new(&name, Span::mixed_site());
             parse_quote!(::#crate_ident)
         })
-        .map_err(|msg| syn::Error::new(Span::mixed_site(), msg))
+        .map_err(|msg| {
+            darling::Error::custom(msg)
+                .with_span(&darling::util::SpannedValue::new((), Span::mixed_site()))
+        })
 }
 
 /// Produces a token stream in the form of `::serde` or renamed version
-pub fn serde_crate() -> Result<Path, syn::Error> {
+pub fn serde_crate() -> darling::Result<Path> {
     let root = entity_crate()?;
     Ok(parse_quote!(#root::vendor::macros::serde))
 }
 
 /// Produces a token stream in the form of `::typetag` or renamed version
-pub fn typetag_crate() -> Result<Path, syn::Error> {
+pub fn typetag_crate() -> darling::Result<Path> {
     let root = entity_crate()?;
     Ok(parse_quote!(#root::vendor::macros::typetag))
 }
@@ -119,13 +122,13 @@ pub fn nested_meta_iter_into_named_attr_map<'a, I: Iterator<Item = &'a NestedMet
 }
 
 /// Extracts and returns the named fields from the input, if possible
-pub fn get_named_fields(input: &DeriveInput) -> Result<&FieldsNamed, syn::Error> {
+pub fn get_named_fields(input: &DeriveInput) -> darling::Result<&FieldsNamed> {
     match &input.data {
         Data::Struct(x) => match &x.fields {
             Fields::Named(x) => Ok(x),
-            _ => Err(syn::Error::new(input.span(), "Expected named fields")),
+            _ => Err(darling::Error::custom("Expected named fields").with_span(input)),
         },
-        _ => Err(syn::Error::new(input.span(), "Expected struct")),
+        _ => Err(darling::Error::custom("Expected struct").with_span(input)),
     }
 }
 
@@ -177,17 +180,17 @@ pub fn type_to_ident(input: &Type) -> Option<&Ident> {
 
 /// If given a type of Option<T>, will strip the outer type and return
 /// a reference to type of T, returning an error if anything else
-pub fn strip_option(input: &Type) -> Result<&Type, syn::Error> {
+pub fn strip_option(input: &Type) -> darling::Result<&Type> {
     strip_for_type_str(input, "Option")
 }
 
 /// If given a type of Vec<T>, will strip the outer type and return
 /// a reference to type of T, returning an error if anything else
-pub fn strip_vec(input: &Type) -> Result<&Type, syn::Error> {
+pub fn strip_vec(input: &Type) -> darling::Result<&Type> {
     strip_for_type_str(input, "Vec")
 }
 
-fn strip_for_type_str<'a, 'b>(input: &'a Type, ty_str: &'b str) -> Result<&'a Type, syn::Error> {
+fn strip_for_type_str<'a, 'b>(input: &'a Type, ty_str: &'b str) -> darling::Result<&'a Type> {
     match input {
         Type::Path(x) => match x.path.segments.last() {
             Some(x) if x.ident.to_string().to_lowercase() == ty_str.to_lowercase() => {
@@ -195,33 +198,36 @@ fn strip_for_type_str<'a, 'b>(input: &'a Type, ty_str: &'b str) -> Result<&'a Ty
                     PathArguments::AngleBracketed(x) if x.args.len() == 1 => {
                         match x.args.last().unwrap() {
                             GenericArgument::Type(x) => Ok(x),
-                            _ => Err(syn::Error::new(
-                                x.span(),
-                                format!("Unexpected type argument for {}", ty_str),
-                            )),
+                            _ => Err(darling::Error::custom(format!(
+                                "Unexpected type argument for {}",
+                                ty_str
+                            ))
+                            .with_span(x)),
                         }
                     }
-                    PathArguments::AngleBracketed(_) => Err(syn::Error::new(
-                        x.span(),
-                        format!("Unexpected number of type parameters for {}", ty_str),
-                    )),
-                    PathArguments::Parenthesized(_) => Err(syn::Error::new(
-                        x.span(),
-                        format!("Unexpected {}(...) instead of {}<...>", ty_str, ty_str),
-                    )),
-                    PathArguments::None => Err(syn::Error::new(
-                        x.span(),
-                        format!("{} missing generic parameter", ty_str),
-                    )),
+                    PathArguments::AngleBracketed(_) => Err(darling::Error::custom(format!(
+                        "Unexpected number of type parameters for {}",
+                        ty_str
+                    ))
+                    .with_span(x)),
+                    PathArguments::Parenthesized(_) => Err(darling::Error::custom(format!(
+                        "Unexpected {}(...) instead of {}<...>",
+                        ty_str, ty_str
+                    ))
+                    .with_span(x)),
+                    PathArguments::None => Err(darling::Error::custom(format!(
+                        "{} missing generic parameter",
+                        ty_str
+                    ))
+                    .with_span(x)),
                 }
             }
-            Some(x) => Err(syn::Error::new(
-                x.span(),
-                format!("Type is not {}<...>", ty_str),
-            )),
-            None => Err(syn::Error::new(x.span(), "Expected type to have a path")),
+            Some(x) => {
+                Err(darling::Error::custom(format!("Type is not {}<...>", ty_str)).with_span(x))
+            }
+            None => Err(darling::Error::custom("Expected type to have a path").with_span(x)),
         },
-        x => Err(syn::Error::new(x.span(), "Expected type to be a path")),
+        x => Err(darling::Error::custom("Expected type to be a path").with_span(x)),
     }
 }
 
@@ -231,18 +237,18 @@ pub fn get_inner_type_from_segment(
     seg: &PathSegment,
     pos: usize,
     max_supported: usize,
-) -> Result<&Type, syn::Error> {
+) -> darling::Result<&Type> {
     match &seg.arguments {
         PathArguments::AngleBracketed(x) => {
             if x.args.len() <= max_supported && x.args.len() > pos {
                 match x.args.iter().nth(pos).unwrap() {
                     GenericArgument::Type(x) => Ok(x),
-                    _ => Err(syn::Error::new(seg.span(), "Unexpected type argument")),
+                    _ => Err(darling::Error::custom("Unexpected type argument").with_span(seg)),
                 }
             } else {
-                Err(syn::Error::new(seg.span(), "Invalid total type arguments"))
+                Err(darling::Error::custom("Invalid total type arguments").with_span(seg))
             }
         }
-        _ => Err(syn::Error::new(seg.span(), "Unsupported type")),
+        _ => Err(darling::Error::custom("Unsupported type").with_span(seg)),
     }
 }


### PR DESCRIPTION
This fully flips to using `darling::Error` in place of `syn::Error`, which lights up better error spans (and will soon facilitate error accumulation for duplicate fields). All the `trybuild` tests fail now because the errors got moved.