### PR TITLE
Accumulate errors during struct parsing

### DIFF
--- a/entity_macros/tests/ui/derive/ent/duplicate-multiple_fields.rs
+++ b/entity_macros/tests/ui/derive/ent/duplicate-multiple_fields.rs
@@ -1,0 +1,27 @@
+//! This test ensures that all errors with a given macro invocation are returned
+//! at once, as opposed to returning after the first error.
+
+use entity::{Ent, Id, WeakDatabaseRc};
+
+#[derive(Clone, Ent)]
+struct TestEnt {
+    #[ent(id)]
+    id: Id,
+
+    #[ent(database)]
+    database: WeakDatabaseRc,
+
+    #[ent(created)]
+    created: u64,
+
+    #[ent(created)]
+    created2: u64,
+
+    #[ent(last_updated)]
+    last_updated: u64,
+
+    #[ent(last_updated)]
+    last_updated2: u64,
+}
+
+fn main() {}

--- a/entity_macros/tests/ui/derive/ent/duplicate-multiple_fields.stderr
+++ b/entity_macros/tests/ui/derive/ent/duplicate-multiple_fields.stderr
@@ -1,0 +1,11 @@
+error: Already have a created timestamp elsewhere
+  --> $DIR/duplicate-multiple_fields.rs:18:5
+   |
+18 |     created2: u64,
+   |     ^^^^^^^^
+
+error: Already have a last_updated timestamp elsewhere
+  --> $DIR/duplicate-multiple_fields.rs:24:5
+   |
+24 |     last_updated2: u64,
+   |     ^^^^^^^^^^^^^


### PR DESCRIPTION
Deriving structs will now have all their errors returned at once instead of having only the first error returned. The included `trybuild` test illustrates the new behavior.