### PR TITLE
Validate Ent input fields are only one ent field

### DIFF
--- a/entity_macros/src/derive/ent/struct/data/internal.rs
+++ b/entity_macros/src/derive/ent/struct/data/internal.rs
@@ -98,7 +98,7 @@ impl EntField {
     pub fn validate_zero_or_one_known_fields(&self) -> darling::Result<()> {
         if self.declares_multiple_known_fields() {
             let mut errors = vec![];
-            for item in vec![&self.id, &self.database, &self.created, &self.last_updated] {
+            for item in &[&self.id, &self.database, &self.created, &self.last_updated] {
                 if let Some(word) = item {
                     errors.push(darling::Error::custom("A field can only declare one of `id`, `database`, `created`, or `last_updated`").with_span(word));
                 }

--- a/entity_macros/src/derive/ent/struct/data/internal.rs
+++ b/entity_macros/src/derive/ent/struct/data/internal.rs
@@ -32,14 +32,18 @@ pub struct Ent {
 pub struct EntField {
     pub ident: Option<Ident>,
     pub ty: Type,
+    /// Location of the word `id`, if present.
     #[darling(default)]
-    pub id: Option<SpannedValue<()>>,
+    id: Option<SpannedValue<()>>,
+    /// Location of the word `database`, if present.
     #[darling(default)]
-    pub database: Option<SpannedValue<()>>,
+    database: Option<SpannedValue<()>>,
+    /// Location of the word `created`, if present.
     #[darling(default)]
-    pub created: Option<SpannedValue<()>>,
+    created: Option<SpannedValue<()>>,
+    /// Location of the word `last_updated`, if present.
     #[darling(default)]
-    pub last_updated: Option<SpannedValue<()>>,
+    last_updated: Option<SpannedValue<()>>,
     #[darling(default, rename = "field")]
     pub field_attr: Option<Override<FieldAttr>>,
     #[darling(default, rename = "edge")]

--- a/entity_macros/src/derive/ent/struct/data/internal.rs
+++ b/entity_macros/src/derive/ent/struct/data/internal.rs
@@ -1,5 +1,9 @@
 use super::EntEdgeDeletionPolicy;
-use darling::{ast, util::Override, FromDeriveInput, FromField, FromMeta};
+use darling::{
+    ast,
+    util::{Override, SpannedValue},
+    FromDeriveInput, FromField, FromMeta,
+};
 use syn::{Generics, Ident, Type, Visibility};
 
 /// Information about a struct deriving ent
@@ -28,22 +32,83 @@ pub struct Ent {
 pub struct EntField {
     pub ident: Option<Ident>,
     pub ty: Type,
-    #[darling(default, rename = "id")]
-    pub is_ent_id_field: bool,
-    #[darling(default, rename = "database")]
-    pub is_ent_database_field: bool,
-    #[darling(default, rename = "created")]
-    pub is_ent_created_field: bool,
-    #[darling(default, rename = "last_updated")]
-    pub is_ent_last_updated_field: bool,
+    #[darling(default)]
+    pub id: Option<SpannedValue<()>>,
+    #[darling(default)]
+    pub database: Option<SpannedValue<()>>,
+    #[darling(default)]
+    pub created: Option<SpannedValue<()>>,
+    #[darling(default)]
+    pub last_updated: Option<SpannedValue<()>>,
     #[darling(default, rename = "field")]
     pub field_attr: Option<Override<FieldAttr>>,
     #[darling(default, rename = "edge")]
     pub edge_attr: Option<EdgeAttr>,
 }
 
+impl EntField {
+    pub fn is_id_field(&self) -> bool {
+        self.id.is_some()
+    }
+
+    pub fn is_database_field(&self) -> bool {
+        self.database.is_some()
+    }
+
+    pub fn is_created_field(&self) -> bool {
+        self.created.is_some()
+    }
+
+    pub fn is_last_updated_field(&self) -> bool {
+        self.last_updated.is_some()
+    }
+
+    /// Check whether this field is trying to declare itself as multiple ent fields.
+    /// This is nonsensical, and indicates an error on the part of the caller.
+    ///
+    /// # Example
+    /// This would return true for `#[ent(id, database)]`.
+    fn declares_multiple_known_fields(&self) -> bool {
+        let mut known_fields_declared = 0;
+        if self.is_id_field() {
+            known_fields_declared += 1;
+        }
+
+        if self.is_database_field() {
+            known_fields_declared += 1;
+        }
+
+        if self.is_created_field() {
+            known_fields_declared += 1;
+        }
+
+        if self.is_last_updated_field() {
+            known_fields_declared += 1;
+        }
+
+        known_fields_declared > 1
+    }
+
+    /// Validate that at most one of `id`, `database`, `created`, and `last_updated` are declared.
+    /// If that is not the case, create properly-spanned errors for each declaration.
+    pub fn validate_zero_or_one_known_fields(&self) -> darling::Result<()> {
+        if self.declares_multiple_known_fields() {
+            let mut errors = vec![];
+            for item in vec![&self.id, &self.database, &self.created, &self.last_updated] {
+                if let Some(word) = item {
+                    errors.push(darling::Error::custom("A field can only declare one of `id`, `database`, `created`, or `last_updated`").with_span(word));
+                }
+            }
+
+            Err(darling::Error::multiple(errors))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// Information for a field attribute on a field of a struct deriving ent
-#[derive(Debug, Default, FromMeta)]
+#[derive(Debug, Clone, Default, FromMeta)]
 #[darling(default)]
 pub struct FieldAttr {
     pub indexed: bool,
@@ -51,7 +116,7 @@ pub struct FieldAttr {
 }
 
 /// Information for an edge attribute on a field of a struct deriving ent
-#[derive(Debug, FromMeta)]
+#[derive(Debug, Clone, FromMeta)]
 pub struct EdgeAttr {
     #[darling(rename = "type")]
     pub r#type: String,

--- a/entity_macros/tests/ui/derive/ent/multiple-known-fields.rs
+++ b/entity_macros/tests/ui/derive/ent/multiple-known-fields.rs
@@ -1,0 +1,23 @@
+//! Test that trying to declare multiple ent-fields on a single field fails properly.
+//!
+//! This test **must not** claim that `TestEnt` is missing any required `ent` fields;
+//! if it does, that likely indicates a bug where field analysis is bailing out too early.
+
+use entity::{Ent, Id, WeakDatabaseRc};
+
+#[derive(Clone, Ent)]
+struct TestEnt {
+    #[ent(id, database)]
+    id: Id,
+
+    #[ent(database, id)]
+    database: WeakDatabaseRc,
+
+    #[ent(created, last_updated)]
+    created: u64,
+
+    #[ent(last_updated, id)]
+    last_updated: u64,
+}
+
+fn main() {}

--- a/entity_macros/tests/ui/derive/ent/multiple-known-fields.stderr
+++ b/entity_macros/tests/ui/derive/ent/multiple-known-fields.stderr
@@ -1,0 +1,71 @@
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+ --> $DIR/multiple-known-fields.rs:5:11
+  |
+5 |     #[ent(id, database)]
+  |           ^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+ --> $DIR/multiple-known-fields.rs:5:15
+  |
+5 |     #[ent(id, database)]
+  |               ^^^^^^^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+ --> $DIR/multiple-known-fields.rs:8:21
+  |
+8 |     #[ent(database, id)]
+  |                     ^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+ --> $DIR/multiple-known-fields.rs:8:11
+  |
+8 |     #[ent(database, id)]
+  |           ^^^^^^^^
+
+error: Already have an id elsewhere
+ --> $DIR/multiple-known-fields.rs:9:5
+  |
+9 |     database: WeakDatabaseRc,
+  |     ^^^^^^^^
+
+error: Already have a database elsewhere
+ --> $DIR/multiple-known-fields.rs:9:5
+  |
+9 |     database: WeakDatabaseRc,
+  |     ^^^^^^^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+  --> $DIR/multiple-known-fields.rs:11:11
+   |
+11 |     #[ent(created, last_updated)]
+   |           ^^^^^^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+  --> $DIR/multiple-known-fields.rs:11:20
+   |
+11 |     #[ent(created, last_updated)]
+   |                    ^^^^^^^^^^^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+  --> $DIR/multiple-known-fields.rs:14:25
+   |
+14 |     #[ent(last_updated, id)]
+   |                         ^^
+
+error: A field can only declare one of `id`, `database`, `created`, or `last_updated`
+  --> $DIR/multiple-known-fields.rs:14:11
+   |
+14 |     #[ent(last_updated, id)]
+   |           ^^^^^^^^^^^^
+
+error: Already have an id elsewhere
+  --> $DIR/multiple-known-fields.rs:15:5
+   |
+15 |     last_updated: u64,
+   |     ^^^^^^^^^^^^
+
+error: Already have a last_updated timestamp elsewhere
+  --> $DIR/multiple-known-fields.rs:15:5
+   |
+15 |     last_updated: u64,
+   |     ^^^^^^^^^^^^


### PR DESCRIPTION
The `#[ent(...)]` attribute syntax is convenient and readable, but has
some implicit requirements that are not expressed in the API syntax.
The macro already enforced the requirement that known fields such as
`id` can only be declared once per struct, but it didn't enforce that
a single input field can only be one ent field.

This commit adds that validation, and amends the existing validation to
ensure that no spurious "missing field" errors are emitted due to the
order of branches in field analysis.

Fixes #30